### PR TITLE
fixed the output type for the findParetoSet function

### DIFF
--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,7 +6,7 @@
 using namespace Rcpp;
 
 // findParetoSet
-NumericMatrix findParetoSet(SEXP idealPoints);
+DataFrame findParetoSet(SEXP idealPoints);
 RcppExport SEXP _MinimumRcpp_findParetoSet(SEXP idealPointsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;

--- a/src/findParetoSet.cpp
+++ b/src/findParetoSet.cpp
@@ -44,7 +44,7 @@ namespace Rcpp {
 //' @param idealPoints ...
 //' @export
 // [[Rcpp::export]]
-NumericMatrix findParetoSet( SEXP idealPoints ){
+DataFrame findParetoSet( SEXP idealPoints ){
   Polygon poly = as<Polygon>(idealPoints);
   Polygon hull;
   boost::geometry::convex_hull(poly, hull);


### PR DESCRIPTION
Changed the output type for the `findParetoSet` function from `NumericMatrix` to `DataFrame`. Not a big change since both types are `SEXP` expressions that are interpreted by r so function return type was all that had to change. 