### PR TITLE
kintersection print polygons issue fixed

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -12,8 +12,9 @@ findParetoSet <- function(idealPoints) {
 #' @param polyList An R list containing DataFrames with 2 columns names 'x' and 'y' representing polygon points
 #' @param k Number of intersections user is looking for
 #' @param epsilon Error tolerance
+#' @param printPolygons An optional parameter that allows user to print inputted polygons. Default value is false
 #' @export
-kintersection <- function(polyList, k, epsilon) {
-    .Call(`_MinimumRcpp_kintersection`, polyList, k, epsilon)
+kintersection <- function(polyList, k, epsilon, printPolygons = FALSE) {
+    .Call(`_MinimumRcpp_kintersection`, polyList, k, epsilon, printPolygons)
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -17,22 +17,23 @@ BEGIN_RCPP
 END_RCPP
 }
 // kintersection
-Rcpp::List kintersection(Rcpp::List polyList, const int k, const double epsilon);
-RcppExport SEXP _MinimumRcpp_kintersection(SEXP polyListSEXP, SEXP kSEXP, SEXP epsilonSEXP) {
+Rcpp::List kintersection(Rcpp::List polyList, const int k, const double epsilon, bool printPolygons);
+RcppExport SEXP _MinimumRcpp_kintersection(SEXP polyListSEXP, SEXP kSEXP, SEXP epsilonSEXP, SEXP printPolygonsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type polyList(polyListSEXP);
     Rcpp::traits::input_parameter< const int >::type k(kSEXP);
     Rcpp::traits::input_parameter< const double >::type epsilon(epsilonSEXP);
-    rcpp_result_gen = Rcpp::wrap(kintersection(polyList, k, epsilon));
+    Rcpp::traits::input_parameter< bool >::type printPolygons(printPolygonsSEXP);
+    rcpp_result_gen = Rcpp::wrap(kintersection(polyList, k, epsilon, printPolygons));
     return rcpp_result_gen;
 END_RCPP
 }
 
 static const R_CallMethodDef CallEntries[] = {
     {"_MinimumRcpp_findParetoSet", (DL_FUNC) &_MinimumRcpp_findParetoSet, 1},
-    {"_MinimumRcpp_kintersection", (DL_FUNC) &_MinimumRcpp_kintersection, 3},
+    {"_MinimumRcpp_kintersection", (DL_FUNC) &_MinimumRcpp_kintersection, 4},
     {NULL, NULL, 0}
 };
 

--- a/src/kintersection.cpp
+++ b/src/kintersection.cpp
@@ -66,9 +66,10 @@ inline Polygon2D& polygonRef(std::pair<const std::set<std::size_t>, Polygon2D>& 
 //' @param polyList An R list containing DataFrames with 2 columns names 'x' and 'y' representing polygon points
 //' @param k Number of intersections user is looking for
 //' @param epsilon Error tolerance
+//' @param printPolygons An optional parameter that allows user to print inputted polygons. Default value is false
 //' @export
 // [[Rcpp::export]]
-Rcpp::List kintersection( Rcpp::List polyList, const int k, const double epsilon ){
+Rcpp::List kintersection( Rcpp::List polyList, const int k, const double epsilon, bool printPolygons = false ){
   /* Error checking before anything begins */
   if( k == 0 )
     Rcpp::stop("Invalid Argument: Zero-intersection is illegal");
@@ -92,12 +93,12 @@ Rcpp::List kintersection( Rcpp::List polyList, const int k, const double epsilon
     D = as<DataFrame>(polyList(i));
     x = D["x"];
     y = D["y"];
-    Rcout << "POLYGON " << i+1 << std::endl;
+    if( printPolygons ) Rcout << "POLYGON " << i+1 << std::endl;
     for( int c = 0; c < x.size(); c++ ){
       boost::geometry::set<0>(p,x(c));
       boost::geometry::set<1>(p,y(c));
       boost::geometry::append(poly.outer(), p);
-      Rcout << x(c) << " " << y(c) << std::endl;
+      if( printPolygons ) Rcout << x(c) << " " << y(c) << std::endl;
     }
     local_plist.push_back(poly);
   }


### PR DESCRIPTION
Added an optional parameter to the `kintersection` function that allows the user to print the input polygons if set to true. If omitted, the same function will execute but with the default value `false` and will not print the input polygons. If the parameter is set to `false` then it obviously won't print either. 